### PR TITLE
[Bugfix] fix create instance crash in macOS (Apple M1 Max, macOS 15.4)

### DIFF
--- a/sandbox/sandbox.cpp
+++ b/sandbox/sandbox.cpp
@@ -29,6 +29,10 @@ int main(int argc, char** argv) {
     std::vector<const char*> extensions(count);
     SDL_Vulkan_GetInstanceExtensions(window, &count, extensions.data());
 
+#ifdef __APPLE__
+    extensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+#endif
+
     toy2d::Init(extensions,
         [&](VkInstance instance){
             VkSurfaceKHR surface;

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -61,6 +61,10 @@ vk::Instance Context::createInstance(std::vector<const char*>& extensions) {
     std::vector<const char*> layers = {"VK_LAYER_KHRONOS_validation"};
     info.setPEnabledLayerNames(layers);
 
+#ifdef __APPLE__
+    info.setFlags(vk::InstanceCreateFlagBits::eEnumeratePortabilityKHR);
+#endif
+
     return vk::createInstance(info);
 }
 


### PR DESCRIPTION
VulkanSDK: 1.4.309.0
macOS: 15.4
Chip: Apple M1 Max

error message: 
terminating due to uncaught exception of type vk::IncompatibleDriverError: vk::createInstance: ErrorIncompatibleDriver